### PR TITLE
Updated line 102

### DIFF
--- a/hanoi.s
+++ b/hanoi.s
@@ -91,7 +91,7 @@ print_all:
   lea -64(%rbp), %rdi
   call print_tower
   lea -128(%rbp), %rdi
-  call print_tower
+  call print_towertake
   lea -192(%rbp), %rdi
   call print_tower
   call print_newline
@@ -99,7 +99,7 @@ print_all:
 print_even:
   lea -64(%rbp), %rdi
   call print_tower
-  lea -196(%rbp), %rdi
+  lea -192(%rbp), %rdi
   call print_tower
   lea -128(%rbp), %rdi
   call print_tower

--- a/hanoi.s
+++ b/hanoi.s
@@ -91,7 +91,7 @@ print_all:
   lea -64(%rbp), %rdi
   call print_tower
   lea -128(%rbp), %rdi
-  call print_towertake
+  call print_tower
   lea -192(%rbp), %rdi
   call print_tower
   call print_newline


### PR DESCRIPTION
Earlier it was trying to access the incorrect memory location. If you read the rest of the code you see that the base address for the third tower is at an offset of 192 and not 196 with respect to the address in rsp. This should make the code work for all test cases.